### PR TITLE
Исправление отображения 0.00% в DefaultTooltip

### DIFF
--- a/WpfView-Net5/DefaultTooltip.xaml
+++ b/WpfView-Net5/DefaultTooltip.xaml
@@ -42,11 +42,7 @@
         <wpf:ChartPointLabelConverter x:Key="ChartPointLabelConverter"/>
         <wpf:ParticipationVisibilityConverter x:Key="ParticipationVisibilityConverter"/>
         <BooleanToVisibilityConverter x:Key="Bvc"></BooleanToVisibilityConverter>
-        <CollectionViewSource x:Key="GroupedPoints" Source="{Binding Data.Points}" >
-            <CollectionViewSource.GroupDescriptions>
-                <PropertyGroupDescription PropertyName="ChartPoint.SeriesView.Grouping" />
-            </CollectionViewSource.GroupDescriptions>
-        </CollectionViewSource>
+        <CollectionViewSource x:Key="GroupedPoints" Source="{Binding Data.Points}"/>
     </UserControl.Resources>
     <UserControl.Template>
         <ControlTemplate>

--- a/WpfView-Net5/DefaultTooltip.xaml
+++ b/WpfView-Net5/DefaultTooltip.xaml
@@ -95,7 +95,7 @@
                                         <TextBlock Grid.Column="3" Text="{Binding ChartPoint.Participation, StringFormat={}{0:P}}" 
                                                VerticalAlignment="Center" Margin="5 0 0 0"
                                                Visibility="{Binding DataContext.Data, RelativeSource={RelativeSource  FindAncestor, 
-                                                                                                    AncestorType={x:Type StackPanel}}, 
+                                                                                                    AncestorType={x:Type ItemsControl}}, 
                                                                     Converter={StaticResource ParticipationVisibilityConverter}}"/>
                                     </Grid>
                                 </DataTemplate>

--- a/WpfView/DefaultTooltip.xaml
+++ b/WpfView/DefaultTooltip.xaml
@@ -42,11 +42,7 @@
         <wpf:ChartPointLabelConverter x:Key="ChartPointLabelConverter"/>
         <wpf:ParticipationVisibilityConverter x:Key="ParticipationVisibilityConverter"/>
         <BooleanToVisibilityConverter x:Key="Bvc"></BooleanToVisibilityConverter>
-        <CollectionViewSource x:Key="GroupedPoints" Source="{Binding Data.Points}" >
-            <CollectionViewSource.GroupDescriptions>
-                <PropertyGroupDescription PropertyName="ChartPoint.SeriesView.Grouping" />
-            </CollectionViewSource.GroupDescriptions>
-        </CollectionViewSource>
+        <CollectionViewSource x:Key="GroupedPoints" Source="{Binding Data.Points}"/>
     </UserControl.Resources>
     <UserControl.Template>
         <ControlTemplate>

--- a/WpfView/DefaultTooltip.xaml
+++ b/WpfView/DefaultTooltip.xaml
@@ -95,7 +95,7 @@
                                         <TextBlock Grid.Column="3" Text="{Binding ChartPoint.Participation, StringFormat={}{0:P}}" 
                                                VerticalAlignment="Center" Margin="5 0 0 0"
                                                Visibility="{Binding DataContext.Data, RelativeSource={RelativeSource  FindAncestor, 
-                                                                                                    AncestorType={x:Type StackPanel}}, 
+                                                                                                    AncestorType={x:Type ItemsControl}}, 
                                                                     Converter={StaticResource ParticipationVisibilityConverter}}"/>
                                     </Grid>
                                 </DataTemplate>


### PR DESCRIPTION
Некорректная привязка к FindAncestor и свойству GroupDescriptions приводят к тому, что отображение процентов не скрывается при отсутствии значений. Данное исправление устраняет этот недочет.